### PR TITLE
Split Dockerfile in muliple stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.10-slim
+# Build stage
+FROM python:3.10-slim AS builder
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -10,14 +11,22 @@ WORKDIR /home
 
 ENV PYTHONPATH=.
 
-COPY requirements.txt /home/requirements.txt
+COPY requirements.txt .
+
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Runtime stage
+FROM python:3.10-slim
+
+WORKDIR /home
+
+COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
 COPY meme_search /home/meme_search
 COPY .streamlit /home/.streamlit
 
-RUN pip3 install -r /home/requirements.txt
-
 EXPOSE 8501
 
-HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
+HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health || exit 1
 
 ENTRYPOINT ["streamlit", "run", "/home/meme_search/app.py", "--server.port=8501", "--server.address=0.0.0.0"]


### PR DESCRIPTION
The current Docker image size is approximately 9GB, which is quite large. To address this, I propose splitting the image into two stages:

    Build stage: This stage will install all dependencies and run the Python requirements.
    Runtime stage: This stage will only copy the necessary Python packages and binaries.

This approach has significantly reduced the Docker image size by approximately 4GB during my tests.

![image](https://github.com/user-attachments/assets/aca0256e-b099-4471-935a-34a97c7c94f6)

Also, are there any python packages that don't need to be installed if I'm running without a gpu? If there are, I would also recommend removing them from the original requirements and adding them in the Dockerfile, conditioned by an Environment variable. Something like:
```
RUN if [ "$ENABLE_GPU" = "true" ]; then \
        echo "torch" >> requirements.txt ; \
    fi 
```
Or even better, have 2 reqiurements.txt files (requirements-cpu.txt and requirements-gpu.txt) and copy the required one, based on a env variable.
